### PR TITLE
Begin ignoring new commits of .csv and .gz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 #File extensions to ignore
-#*.csv
-#*.gz
+*.csv
+*.gz
 
 #Mac clean-up
 *.ds_store


### PR DESCRIPTION
previously commented out those instructions in order to load 'source of truth' data, now they should be activated